### PR TITLE
Fixing DZSlides for Chrome

### DIFF
--- a/shells/master.html
+++ b/shells/master.html
@@ -111,6 +111,9 @@
             views.remote.postMessage("setSlide(" + idx + ")", document.location);
         }, 1000);
     }
+    window.addEventListener("load", onload, false);
+    window.addEventListener("message", onmessage, false);
+    window.addEventListener("keydown", onkeydown, false);
 </script>
 
 <style>


### PR DESCRIPTION
A fix for paulrouget/dzslides#4:

Event listener functions have to be explicitly registered with the window in
Google Chrome/Chromium. Luckily, this fix doesn't break any functionality in
Firefox.
