### PR TITLE
Fixing the quote width

### DIFF
--- a/template.html
+++ b/template.html
@@ -80,7 +80,7 @@
 
   q {
     display: inline-block;
-    width: 800px;
+    width: 700px;
     height: 600px;
     background-color: black;
     color: white;
@@ -398,4 +398,3 @@
     return next;
   }
 </script>
-<!-- vim: set fdm=marker: }}} -->


### PR DESCRIPTION
The `<q>` styling didn't take into account the padding and so the quote overflowed.

Attached is the fix (though it's only one line!)
