### PR TITLE
Adding progress-bar feature

### DIFF
--- a/template.html
+++ b/template.html
@@ -133,6 +133,15 @@
   /* The items to-be-selected */
   .incremental > *[aria-selected] ~ * { opacity: 0.2; }
 
+  #progress-bar, #progress-value { height: 2px; }
+  #progress-bar { bottom: 0; position: absolute; width: 100%; }
+  #progress-value { 
+    background: #AAA; 
+    -moz-transition: width 400ms linear 0s;
+    -webkit-transition: width 400ms linear 0s;
+    -ms-transition: width 400ms linear 0s;
+    transition: width 400ms linear 0s;
+  }
 </style>
 
 <!-- {{{{ dzslides core
@@ -148,6 +157,8 @@
 # feel free to hack it!
 #
 -->
+
+<div id="progress-bar"><div id="progress-value"></div></div>
 
 <!-- Default Style -->
 <style>
@@ -178,6 +189,7 @@
     idx: -1,
     step: 0,
     slides: null,
+    progressValue : null,
     params: {
       autoplay: "1"
     }
@@ -186,6 +198,7 @@
   Dz.init = function() {
     document.body.className = "loaded";
     this.slides = $$("body > section");
+    this.progressValue = $("#progress-value");
     this.setupParams();
     this.onhashchange();
     this.setupTouchEvents();
@@ -352,6 +365,7 @@
         newidx++;
       }
     }
+    this.setProgress(newidx, newstep);
     if (newidx != this.idx) {
       this.setSlide(newidx);
     }
@@ -452,6 +466,16 @@
       setCursor(this.idx, 0);
     }
     return next;
+  }
+  
+  Dz.setProgress = function(aIdx, aStep) {
+    var slide = $("section:nth-of-type("+ aIdx +")");
+    if (!slide)
+      return;
+    var steps = slide.$$('.incremental > *').length + 1,
+        slideSize = 100 / (this.slides.length - 1),
+        stepSize = slideSize / steps;
+    this.progressValue.style.width = ((aIdx - 1) * slideSize + aStep * stepSize) + '%';
   }
   
   Dz.postMsg = function(aWin, aMsg) { // [arg0, [arg1...]]


### PR DESCRIPTION
As we discussed it in #49, #32 and #45, I added a progress bar feature. It takes full cursor into account (index and incremental).

If the progress bar is removed, it doesn't work anymore. Should I move the `<div>` after the DZslides core declaration ?

This could be done without manipulation directly the `#progress-bar` element but support for CSS `attr()` on all properties is weak. Should I provide it anyway?
