### PR TITLE
Fixing video controls if autoplay=0 (#40)

### DIFF
--- a/template.html
+++ b/template.html
@@ -242,6 +242,9 @@
       var keyVal = e.split('=');
       Dz.params[keyVal[0]] = decodeURIComponent(keyVal[1]);
     });
+  // Specific params handling
+    if (!+this.params.autoplay)
+      $$.forEach($$("video"), function(v){ v.controls = true });
   }
 
   Dz.onkeydown = function(aEvent) {


### PR DESCRIPTION
I implemented it like we discussed in #40.

I have a remark about onstage. Videos now have controls but since we have a `iframe { pointer-events: none; }`, they can't be clicked. Should we remove it ?

On one hand, it's strange to have controls not clickable. On the other hand, it could introduce more focus problems. And when you're using a remote control, it can be annoying. I'm sure you know what I'm talking about ;-)
