### PR TITLE
Display notes on the first slide

### DIFF
--- a/shells/onstage.html
+++ b/shells/onstage.html
@@ -205,8 +205,7 @@
     if (argv[0] === "CURSOR" && argc === 2) {
       if (aEvent.source === this.views.present) {
         var cursor = argv[1].split(".");
-        if (this.idx != ~~cursor[0])
-          this.postMsg(this.views.present, "GET_NOTES");
+        this.postMsg(this.views.present, "GET_NOTES");
         this.idx = ~~cursor[0];
         this.step = ~~cursor[1];
         $("#slideidx").innerHTML = argv[1];


### PR DESCRIPTION
Currently, if you want to display notes (details tag) for the first slide, they do not show up on presenter display (onstage.html). They do show up however, if you move to the next slide and then back to the first one.

This is a fix which will always display notes for the first slide, even on first load.
