### PR TITLE
Display next slide ID as END instead of -1.0

### DIFF
--- a/shells/onstage.html
+++ b/shells/onstage.html
@@ -213,7 +213,7 @@
         if (this.views.remote)
           this.postMsg(this.views.remote, "SET_CURSOR", argv[1]);
       } else {
-        $("#nextslideidx").innerHTML = (argv[1].charAt(0) !== "-") ? argv[1] : "END";
+        $("#nextslideidx").innerHTML = +argv[1] < 0 ? "END" : argv[1];
       }
     }
     if (aEvent.source === this.views.present) {


### PR DESCRIPTION
Currently, onstage.html displays the last slide number as -1.0. 

This is a fix which will display END instead of -1.0 as the last slide's number.
