### PR TITLE
Move figure CSS into userland

### DIFF
--- a/template.html
+++ b/template.html
@@ -121,6 +121,14 @@
      on top of the image/video */
   figure {
     background-color: black;
+    width: 100%;
+    height: 100%;
+  }
+  figure > * {
+    position: absolute;
+  }
+  figure > img, figure > video {
+    width: 100%; height: 100%;
   }
   figcaption {
     margin: 70px;
@@ -261,16 +269,6 @@
   }
   .view #progress-bar {
     display: none;
-  }
-  figure {
-    width: 100%;
-    height: 100%;
-  }
-  figure > * {
-    position: absolute;
-  }
-  figure > img, figure > video {
-    width: 100%; height: 100%;
   }
 </style>
 


### PR DESCRIPTION
Resizing figures is a nice feature, as long as your images are the right shape and size. However, resizing can change the aspect ratio of images, resulting in poor appearance, if the images are not of the right shape.

Currently, the CSS that resizes the figures is inside the dzslides-core section of the template, where editing is somewhat discouraged.

This commit moves the css for figures out of dzslides-core and up into the style tag that is intended for user modification. It's easier to modify this way, for those presentations that need to modify it.
