### PR TITLE
Adding scrollIntoView when passing slides in outline mode

### DIFF
--- a/template.html
+++ b/template.html
@@ -545,6 +545,9 @@
     }
     if (next) {
       next.setAttribute("aria-selected", "true");
+      if (this.html.classList.contains("view")) {
+        next.scrollIntoView();
+      }
       var video = next.$("video");
       if (video && !!+this.params.autoplay) {
         video.play();


### PR DESCRIPTION
Fix issue #95.

A scrollIntoViewIfNeeded would be better but's it's not standard yet. Using the polyfill seems too much just for that.
