### PR TITLE
Aria role instead of details

### DIFF
--- a/template.html
+++ b/template.html
@@ -24,7 +24,7 @@
       <li>Item 2
       <li>Item 3
     </ul>
-    <div role="note">s>Some notes. They are only visible using onstage shell.</div role="note">
+    <div role="note">Some notes. They are only visible using onstage shell.</div>
 </section>
 
 <section>
@@ -42,7 +42,7 @@
       <img src="http://placekitten.com/g/800/600">
       <figcaption>An image</figcaption>
     </figure>
-    <div role="note">Kittens are so cute!</div role="note">
+    <div role="note">Kittens are so cute!</div>
 </section>
 
 <section>


### PR DESCRIPTION
Addressing issue 98
Changed CSS, JavaScript and example HTML

Note that the function getDetails has been renamed
and that this _increases_ naming conistency with
GET_NOTES and NOTES in the onmessage event handler

Notes must not be a div, but can be any kind of HTML-element
that has the aria role="note" attribute set.
