### PR TITLE
minor changes and new approach to incremental slides

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,8 @@ the file in your browser.
 * Resolution independent (slides are scaled according to the size of the browser. The virtual dimension is 800x600);
 * Fullscreen presentation (HTML5 FullScreen API supported) - press `f` to go fullscreen;
 * Incremental content;
-* Mobile Friendly (supports touch events).
+* Mobile Friendly (supports touch events);
+* Printing to PDF
 
 ## Shells
 

--- a/readme.md
+++ b/readme.md
@@ -80,3 +80,8 @@ Parameters a DZSlides page can have:
       TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
     0. You just DO WHAT THE FUCK YOU WANT TO.
+
+## Todo ideas
+
+* Allow many elements to have the same `next-order` number — and activate them all at the same time.
+* 2D presentation structure as in flowtime.js or reveal.js. Many presentations fit naturally into it, even in this `template.html` slides could be arranged in a 2D grid (in the overview) where every Part starts a new row of slides.

--- a/shells/onstage.html
+++ b/shells/onstage.html
@@ -21,7 +21,7 @@
 <div id="slidecount">?</div>
 <button id="popup-button" onclick="Dz.popup()">Pop-up</button>
 
-<div id="time">
+<div id="time" onclick="Dz.resetClock()">
   <span id="hours">00</span>:<span id="minutes">00</span>:<span id="seconds">00</span>
 </div>
 
@@ -82,6 +82,7 @@
     position: absolute;
     text-align: center;
     width: 200px;
+    cursor: pointer;
   }
 
   iframe {
@@ -160,6 +161,7 @@
   };
   
   Dz.init = function() {
+    this.clock_start = 0;
     this.startClock();
     this.loadIframes();
   }
@@ -298,13 +300,17 @@
     aWin.postMessage(aMsg.join(" "), "*");
   }
   
+  Dz.resetClock = function() { // + 3600000, because Date(0) is 01:00:00
+    this.clock_start = (new Date()).getTime() + 3600000;
+  }
+
   Dz.startClock = function() {
     var addZero = function(num) {
       return num < 10 ? '0' + num : num;
     }
     setInterval(function() {
-      var now = new Date();
-      $("#hours").innerHTML = addZero(now.getHours());
+      var now = new Date((new Date()).getTime() - this.Dz.clock_start);
+      $("#hours").innerHTML   = addZero(now.getHours());
       $("#minutes").innerHTML = addZero(now.getMinutes());
       $("#seconds").innerHTML = addZero(now.getSeconds());
     }, 1000);

--- a/template.html
+++ b/template.html
@@ -107,7 +107,7 @@
   }
 
   section, .view head > title {
-      font-size: 30px;
+      font-size: 2rem;
   }
 
   .view section:after {
@@ -126,7 +126,7 @@
   h1 {
     margin: 120px 0 30px 0;
     text-align: center;
-    font-size: 80px;
+    font-size: 5rem;
   }
 
   h2 {
@@ -140,7 +140,7 @@
 
   pre {
     overflow: hidden;
-    font-size: 20px;
+    font-size: 1.25rem;
     margin: 0 75px 0 75px;
     padding: 10px;
     border: 1px solid;
@@ -165,12 +165,12 @@
 
   p {
     margin: 75px 75px 0 75px;
-    font-size: 50px;
+    font-size: 3rem;
   }
 
   table {
     margin: auto;
-    font-size:40px;
+    font-size:2.5rem;
     text-align: center;
   }
 
@@ -178,7 +178,7 @@
     height: 100%;
     background-color: black;
     color: white;
-    font-size: 60px;
+    font-size: 3.75rem;
     padding: 50px;
   }
   blockquote:before {
@@ -203,7 +203,7 @@
   }
   figcaption {
     margin: 70px;
-    font-size: 50px;
+    font-size: 3rem;
   }
 
   header {
@@ -278,6 +278,9 @@
 <style>
   * { margin: 0; padding: 0; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
   [role="note"] { display: none; }
+  html {
+    font-size: 16px;
+  }
   body {
     width: 800px; height: 600px;
     margin-left: -400px; margin-top: -300px;

--- a/template.html
+++ b/template.html
@@ -32,6 +32,13 @@
 </section>
 
 <section>
+    <h3>More incrementals</h3>
+    <p class="next">Not only list elements can appear incrementally</p>
+    <p><mark class="next">Styles</mark> can be incremental
+       <mark class="next">too</mark></p>
+</section>
+
+<section>
   <blockquote>
     Who's brave enough to fly into something we all keep calling a death sphere?
   </blockquote>
@@ -108,6 +115,11 @@
   }
   li > ul {
       margin: 15px 50px;
+  }
+
+  mark.next:not([active]) {
+    visibility: visible; /* override the default behavior where next is hidden */
+    background-color: inherit; /* and disable highlighting instead */
   }
 
   p {

--- a/template.html
+++ b/template.html
@@ -620,7 +620,7 @@
     if (next) {
       next.setAttribute('active', true);
     } else {
-      setCursor(this.idx, 0);
+      this.setCursor(this.idx, 0);
     }
     return next;
   }

--- a/template.html
+++ b/template.html
@@ -19,13 +19,13 @@
 
 <section>
     <h3>An incremental list</h3>
-    <ul class="incremental">
-      <li>Item 1
-      <li>Item 2
-      <li>Item 3
-        <ul class="incremental">
-          <li> Item 3.1
-          <li> Item 3.2
+    <ul>
+      <li class="next">Item 1
+      <li class="next">Item 2
+      <li class="next">Item 3
+        <ul>
+          <li class="next"> Item 3.1
+          <li class="next"> Item 3.2
         </ul>
     </ul>
     <div role="note">Some notes. They are only visible using onstage shell.</div>
@@ -186,17 +186,6 @@
   /* After */
   section[aria-selected] ~ section { left: +150%; }
 
-  /* Incremental elements */
-
-  /* By default, visible */
-  .incremental > * { opacity: 1; }
-
-  /* The current item */
-  .incremental > *[aria-selected] { opacity: 1; }
-
-  /* The items to-be-selected */
-  .incremental > *[aria-selected] ~ * { opacity: 0; }
-
   /* The progressbar, at the bottom of the slides, show the global
      progress of the presentation. */
   #progress-bar {
@@ -269,8 +258,7 @@
   html { overflow: hidden; }
   html.view { overflow: visible; }
   body.loaded { display: block; }
-  .incremental {visibility: hidden; }
-  .incremental[active] {visibility: visible; }
+  .next:not([active]) {visibility: hidden; }
   #progress-bar{
     bottom: 0;
     position: absolute;
@@ -487,7 +475,7 @@
     if (cursor.length == 2) {
       newidx = ~~cursor[1].split(".")[0];
       newstep = ~~cursor[1].split(".")[1];
-      if (newstep > Dz.slides[newidx - 1].$$('.incremental > *').length) {
+      if (newstep > Dz.slides[newidx - 1].$$('.next').length) {
         newstep = 0;
         newidx++;
       }
@@ -505,24 +493,21 @@
   }
 
   Dz.back = function() {
-    if (this.idx == 1 && this.step == 0) {
+    if (this.idx == 1) {
       return;
     }
-    if (this.step == 0) {
-      this.setCursor(this.idx - 1,
-                     this.slides[this.idx - 2].$$('.incremental > *').length);
-    } else {
-      this.setCursor(this.idx, this.step - 1);
-    }
+    this.setCursor(this.idx - 1,
+                   this.slides[this.idx - 2].$$('.next[active]').length);
   }
 
   Dz.forward = function() {
     if (this.idx >= this.slides.length &&
-        this.step >= this.slides[this.idx - 1].$$('.incremental > *').length) {
+        this.step >= this.slides[this.idx - 1].$$('.next').length) {
         return;
     }
-    if (this.step >= this.slides[this.idx - 1].$$('.incremental > *').length) {
-      this.setCursor(this.idx + 1, 0);
+    if (this.step >= this.slides[this.idx - 1].$$('.next').length) {
+      this.setCursor(this.idx + 1,
+                     this.slides[this.idx].$$('.next[active]').length);
     } else {
       this.setCursor(this.idx, this.step + 1);
     }
@@ -534,7 +519,7 @@
 
   Dz.goEnd = function() {
     var lastIdx = this.slides.length;
-    var lastStep = this.slides[lastIdx - 1].$$('.incremental > *').length;
+    var lastStep = this.slides[lastIdx - 1].$$('.next').length;
     this.setCursor(lastIdx, lastStep);
   }
 
@@ -575,31 +560,9 @@
 
   Dz.setIncremental = function(aStep) {
     this.step = aStep;
-    var old = this.slides[this.idx - 1].$('.incremental > *[aria-selected]');
-    if (old) {
-      old.removeAttribute('aria-selected');
-    }
-    var incrementals = $$('.incremental');
-    if (this.step <= 0) {
-      $$.forEach(incrementals, function(aNode) {
-        aNode.removeAttribute('active');
-      });
-      return;
-    }
-    var next = this.slides[this.idx - 1].$$('.incremental > *')[this.step - 1];
+    var next = this.slides[this.idx - 1].$$('.next')[this.step - 1];
     if (next) {
-      next.setAttribute('aria-selected', true);
-      next.parentNode.setAttribute('active', true);
-      var found = false;
-      $$.forEach(incrementals, function(aNode) {
-        if (aNode != next.parentNode)
-          if (found)
-            aNode.removeAttribute('active');
-          else
-            aNode.setAttribute('active', true);
-        else
-          found = true;
-      });
+      next.setAttribute('active', true);
     } else {
       setCursor(this.idx, 0);
     }
@@ -618,7 +581,7 @@
     var slide = $("section:nth-of-type("+ aIdx +")");
     if (!slide)
       return;
-    var steps = slide.$$('.incremental > *').length + 1,
+    var steps = slide.$$('.next').length + 1,
         slideSize = 100 / (this.slides.length - 1),
         stepSize = slideSize / steps;
     this.progressBar.style.width = ((aIdx - 1) * slideSize + aStep * stepSize) + '%';

--- a/template.html
+++ b/template.html
@@ -39,6 +39,20 @@
 </section>
 
 <section>
+    <h3>Even more incrementals</h3>
+    <p>
+      <span class="next" next-order="3">They</span>
+      <span class="next" next-order="5">can</span>
+      <span class="next" next-order="2">even</span>
+      <span class="next" next-order="1">appear</span>
+      <span class="next" next-order="7">in</span>
+      <span class="next" next-order="4">any</span>
+      <span class="next" next-order="6">order</span>
+      <span class="next" next-order="8">!</span>
+    </p>
+</section>
+
+<section>
   <blockquote>
     Who's brave enough to fly into something we all keep calling a death sphere?
   </blockquote>
@@ -572,7 +586,10 @@
 
   Dz.setIncremental = function(aStep) {
     this.step = aStep;
-    var next = this.slides[this.idx - 1].$$('.next')[this.step - 1];
+    var incrementals = Array.prototype.slice.call(this.slides[this.idx - 1].$$('.next')).sort(function(a, b) {
+            return Number(a.getAttribute('next-order')) - Number(b.getAttribute('next-order'));
+          });
+    var next = incrementals[this.step - 1];
     if (next) {
       next.setAttribute('active', true);
     } else {

--- a/template.html
+++ b/template.html
@@ -3,6 +3,13 @@
 <meta charset="utf-8">
 <title>The Title Of Your Presentation</title>
 
+<!-- Optional: on every page: header and footer -->
+<header>
+  Hi, I'm a header
+</header>
+
+<footer>by John Doe</footer>
+
 <!-- Your Slides -->
 <!-- One section is one slide -->
 
@@ -173,14 +180,18 @@
     font-size: 50px;
   }
 
+  header {
+    background-color: #F3F4F8;
+    border-bottom: 1px solid #CCC;
+  }
+
   footer {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    padding: 40px;
-    text-align: right;
     background-color: #F3F4F8;
     border-top: 1px solid #CCC;
+  }
+
+  section footer {
+    padding: 40px;
   }
 
   /* Transition effect */
@@ -296,6 +307,20 @@
   .view #progress-bar {
     display: none;
   }
+  header {
+    text-align: right;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+  footer {
+    text-align: right;
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
+  .view header { display: none; }
+  .view footer { display: none; }
 </style>
 
 <script>

--- a/template.html
+++ b/template.html
@@ -351,6 +351,24 @@
   }
   .view header { display: none; }
   .view footer { display: none; }
+
+/*
+   **************************************
+   Uncomment the following for 16:9 slides
+   **************************************
+
+  html { font-size: 12px; }
+  body { height: 450px; margin-top: -225px; }
+  .view section {
+    height: 450px;
+    margin: -140px -200px;
+    transform: scale(.3);
+    -moz-transform: scale(.3);
+    -webkit-transform: scale(.3);
+    -o-transform: scale(.3);
+    -ms-transform: scale(.3);
+  }
+*/
 </style>
 
 <script>

--- a/template.html
+++ b/template.html
@@ -531,7 +531,8 @@
         this.step >= this.slides[this.idx - 1].$$('.next').length) {
         return;
     }
-    if (this.step >= this.slides[this.idx - 1].$$('.next').length) {
+    if (this.html.classList.contains("view") ||
+        this.step >= this.slides[this.idx - 1].$$('.next').length) {
       this.setCursor(this.idx + 1,
                      this.slides[this.idx].$$('.next[active]').length);
     } else {
@@ -572,10 +573,11 @@
       next.setAttribute("aria-selected", "true");
       if (this.html.classList.contains("view")) {
         next.scrollIntoView();
-      }
-      var video = next.$("video");
-      if (video && !!+this.params.autoplay) {
-        video.play();
+      } else {
+        var video = next.$("video");
+        if (video && !!+this.params.autoplay) {
+          video.play();
+        }
       }
     } else {
       // That should not happen

--- a/template.html
+++ b/template.html
@@ -358,7 +358,9 @@
       aEvent.preventDefault();
       this.goFullscreen();
     }
-    if (aEvent.keyCode == 79) { // o
+    if (aEvent.keyCode == 79    //o
+     || aEvent.keyCode == 27
+    ) {
       aEvent.preventDefault();
       this.toggleView();
     }

--- a/template.html
+++ b/template.html
@@ -227,15 +227,9 @@
      https://developer.mozilla.org/en/CSS/CSS_transitions
      How to use CSS3 Transitions: */
   section {
-    -moz-transition: left 400ms linear 0s;
-    -webkit-transition: left 400ms linear 0s;
-    -ms-transition: left 400ms linear 0s;
     transition: left 400ms linear 0s;
   }
   .view section {
-    -moz-transition: none;
-    -webkit-transition: none;
-    -ms-transition: none;
     transition: none;
   }
 
@@ -276,7 +270,7 @@
 
 <!-- Default Style -->
 <style>
-  * { margin: 0; padding: 0; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
   [role="note"] { display: none; }
   html {
     font-size: 16px;
@@ -296,10 +290,6 @@
     overflow: visible; overflow-x: hidden;
     /* undo Dz.onresize */
     transform: none !important;
-    -moz-transform: none !important;
-    -webkit-transform: none !important;
-    -o-transform: none !important;
-    -ms-transform: none !important;
   }
   .view head, .view head > title { display: block }
   section {
@@ -315,10 +305,6 @@
     float: left;
 
     transform: scale(.4);
-    -moz-transform: scale(.4);
-    -webkit-transform: scale(.4);
-    -o-transform: scale(.4);
-    -ms-transform: scale(.4);
   }
   .view section > * { pointer-events: none; }
   section[aria-selected] { pointer-events: auto; }
@@ -329,9 +315,6 @@
   #progress-bar{
     bottom: 0;
     position: absolute;
-    -moz-transition: width 400ms linear 0s;
-    -webkit-transition: width 400ms linear 0s;
-    -ms-transition: width 400ms linear 0s;
     transition: width 400ms linear 0s;
   }
   .view #progress-bar {
@@ -363,10 +346,6 @@
     height: 450px;
     margin: -140px -200px;
     transform: scale(.3);
-    -moz-transform: scale(.3);
-    -webkit-transform: scale(.3);
-    -o-transform: scale(.3);
-    -ms-transform: scale(.3);
   }
 */
 </style>
@@ -501,11 +480,6 @@
     var sx = db.clientWidth / window.innerWidth;
     var sy = db.clientHeight / window.innerHeight;
     var transform = "scale(" + (1/Math.max(sx, sy)) + ")";
-
-    db.style.MozTransform = transform;
-    db.style.WebkitTransform = transform;
-    db.style.OTransform = transform;
-    db.style.msTransform = transform;
     db.style.transform = transform;
   }
 
@@ -707,10 +681,8 @@
   }
 
   window.onload = init;
-</script>
 
-
-<script> // Helpers
+  // Helpers
   if (!Function.prototype.bind) {
     Function.prototype.bind = function (oThis) {
 

--- a/template.html
+++ b/template.html
@@ -237,12 +237,14 @@
     border: 5px red solid;
   }
 
+@media screen {
   /* Before */
   section { left: -150%; }
   /* Now */
   section[aria-selected] { left: 0; }
   /* After */
   section[aria-selected] ~ section { left: +150%; }
+}
 
   /* The progressbar, at the bottom of the slides, show the global
      progress of the presentation. */
@@ -333,6 +335,17 @@
   }
   .view header { display: none; }
   .view footer { display: none; }
+
+@media print {
+  section {
+    transition: none;
+    transform: none;
+    position: static;
+    page-break-inside: avoid;
+  }
+  body { overflow: visible; }
+  #progress-bar{ display:none; }
+}
 
 /*
    **************************************

--- a/template.html
+++ b/template.html
@@ -71,7 +71,7 @@
 </section>
 
 <section>
-    <h2>Part two</h2>
+    <h1>Part two</h1>
 </section>
 
 <section>
@@ -90,7 +90,7 @@
 </section>
 
 <section>
-    <h2>End!</h2>
+    <h1>End!</h1>
 </section>
 
 <!-- Your Style -->
@@ -101,11 +101,12 @@
 
 <style>
   html, .view body { background-color: black; counter-reset: slideidx; }
-  body, .view section { background-color: white; border-radius: 12px }
-  /* A section is a slide. It's size is 800x600, and this will never change */
+  body, .view section {
+    background-color: white; border-radius: 12px;
+    font-family: 'Oswald', arial, serif;
+  }
+
   section, .view head > title {
-      /* The font from Google */
-      font-family: 'Oswald', arial, serif;
       font-size: 30px;
   }
 
@@ -122,20 +123,39 @@
     margin: 1em 0 1em 0;
   }
 
-  h1, h2 {
-    margin-top: 200px;
+  h1 {
+    margin: 120px 0 30px 0;
     text-align: center;
     font-size: 80px;
   }
-  h3 {
-    margin: 100px 0 50px 100px;
+
+  h2 {
+    text-align: center;
   }
 
-  ul {
-      margin: 50px 200px;
+  section > h3 {
+    margin: 50px 50px 40px 50px;
+    border-bottom: 0.1px solid;
   }
-  li > ul {
-      margin: 15px 50px;
+
+  pre {
+    overflow: hidden;
+    font-size: 20px;
+    margin: 0 75px 0 75px;
+    padding: 10px;
+    border: 1px solid;
+    font-weight: bold;
+    background-color: #F7F7F7;
+    width:80%
+  }
+
+  ul, ol {
+      margin: 40px 100px 0 100px;
+  }
+
+  li > ul, ol {
+      margin: 0 0 15px 50px;
+      list-style-image: none; /* in case parent list has some */
   }
 
   mark.next:not([active]) {
@@ -144,8 +164,14 @@
   }
 
   p {
-    margin: 75px;
+    margin: 75px 75px 0 75px;
     font-size: 50px;
+  }
+
+  table {
+    margin: auto;
+    font-size:40px;
+    text-align: center;
   }
 
   blockquote {
@@ -188,10 +214,11 @@
   footer {
     background-color: #F3F4F8;
     border-top: 1px solid #CCC;
+    padding-bottom: 4px; /* remember progress bar */
   }
 
   section footer {
-    padding: 40px;
+    padding: 10px;
   }
 
   /* Transition effect */
@@ -226,7 +253,7 @@
   /* The progressbar, at the bottom of the slides, show the global
      progress of the presentation. */
   #progress-bar {
-    height: 2px;
+    height: 4px;
     background: #AAA;
   }
 </style>
@@ -398,7 +425,7 @@
       this.goFullscreen();
     }
     if (aEvent.keyCode == 79    //o
-     || aEvent.keyCode == 27
+     || aEvent.keyCode == 27    //Esc
     ) {
       aEvent.preventDefault();
       this.toggleView();

--- a/template.html
+++ b/template.html
@@ -277,7 +277,6 @@
   }
   body {
     width: 800px; height: 600px;
-    margin-left: -400px; margin-top: -300px;
     position: absolute; top: 50%; left: 50%;
     overflow: hidden;
     display: none;
@@ -341,7 +340,7 @@
    **************************************
 
   html { font-size: 12px; }
-  body { height: 450px; margin-top: -225px; }
+  body { height: 450px; }
   .view section {
     height: 450px;
     margin: -140px -200px;
@@ -481,6 +480,8 @@
     var sy = db.clientHeight / window.innerHeight;
     var transform = "scale(" + (1/Math.max(sx, sy)) + ")";
     db.style.transform = transform;
+    db.style.marginTop = -db.clientHeight / 2 + "px";
+    db.style.marginLeft = -db.clientWidth / 2 + "px";
   }
 
 


### PR DESCRIPTION
Here's the description of the commits:

1. "also show overview on Escape" — many javascript-based presentation frameworks show the overview on Esc key (e.g. flowtime.js, reveal.js, shower). dzslides doesn't and I originally thought that overview is not supported. Only later looking at the code I saw that it actually does work. I've made dzslides to show overview on Esc to avoid similar confusions in the future.

2. redo incremental lists: three commits. This changes the approach to incremental lists. Instead of putting "incremenal" in the UL element, one now puts "next" on every LI element. Benefits:
 * more flexible. "next" can be on any element, not only on LI. So any part of the slide can be incremental (there's an example with "next" on P)
 * simpler styles: only one rule to specify the behavior, not four (for UL, for UL:active, for LI, and for LI:aria-selected)
 * because any element can be incremental, the behavior can also be arbitrary styled. There's an example where text highlighting appears incrementally (color:yellow), while the text itself doesn't disappear or appear.
 * another feature: incremental elements can optionally have sequence numbers (using next-order attribute). They will appear in that order. There's an example too.
 * incremental elements behave as in shower — their incremental behavior happens only once, further back()/forward() don't make elements to disappear again. One needs to reload the page to reset incremental elements. This is very important — after a slide is completely shown, you can quickly go back and forth to any slide, answering questions of attendees, and and incremental behavior would only be annoying. I hated that in every my talk (libreoffice, Slidy, etc) — until I saw how shower does it.

3. other commits are pretty much self-explanatory